### PR TITLE
Updated Permissions

### DIFF
--- a/scripts/flow_logs_parser.py
+++ b/scripts/flow_logs_parser.py
@@ -12,7 +12,6 @@ from hashlib import sha1
 
 s3 = boto3.resource('s3',"eu-west-2")
 dynamodb = boto3.client('dynamodb',"eu-west-2")
-ec2 = boto3.client('ec2',"eu-west-2")
 
 regions = ['eu-west-2']
 

--- a/templates/sg_rule_analysis.yaml
+++ b/templates/sg_rule_analysis.yaml
@@ -5,18 +5,49 @@ Parameters:
     Type: String
     Default: ""
 Resources:
-    IAMRole:
-        Type: "AWS::IAM::Role"
-        Properties:
-            Path: "/service-role/"
-            RoleName: "sg-analysis-step-function-role-ks"
-            AssumeRolePolicyDocument: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"states.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
-            MaxSessionDuration: 3600
-            ManagedPolicyArns: 
-              - !Sub "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
-              - !Sub "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
-              - !Sub "arn:aws:iam::aws:policy/AWSXrayFullAccess"
 
+    SgaCloudWatchLogsPolicy:
+        Type: AWS::IAM::ManagedPolicy
+        Properties:
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: "*"
+          Description: Managed policy for CloudWatch Logs for use with the Security Group Analysis Solution
+          Path: "/"
+          ManagedPolicyName: SgaCloudWatchLogsPolicy
+    
+    SgaStepFunctionIAMRole:
+        Type: AWS::IAM::Role
+        Properties:
+          AssumeRolePolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Principal:
+                  Service: states.amazonaws.com
+                Action: sts:AssumeRole
+          Path: /
+          ManagedPolicyArns:
+            - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
+            - !Ref SgaCloudWatchLogsPolicy
+          Policies:
+            - PolicyName: SgaSfLambdaInvokePolicy
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - lambda:InvokeFunction
+                    Resource:
+                      - !GetAtt LambdaGetSG.Arn
+                      - !GetAtt LambdaGetENI.Arn
+    
     IAMManagedPolicy:
         Type: "AWS::IAM::ManagedPolicy"
         Properties:
@@ -37,23 +68,6 @@ Resources:
                         }
                     ]
                 }
-
-    IAMRole2:
-        Type: "AWS::IAM::Role"
-        Properties:
-            Path: "/service-role/"
-            RoleName: "SG_Analysis_Glue_Access_Role_KS"
-            AssumeRolePolicyDocument: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
-            MaxSessionDuration: 3600
-            ManagedPolicyArns: 
-              - "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
-              - "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
-              - "arn:aws:iam::aws:policy/AmazonSESFullAccess"
-              - "arn:aws:iam::aws:policy/CloudWatchFullAccess"
-              - "arn:aws:iam::aws:policy/AmazonAthenaFullAccess"
-              - "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
-              - "arn:aws:iam::aws:policy/AmazonS3FullAccess"
-              - "arn:aws:iam::aws:policy/service-role/AWSLambdaRole"
 
     StepFuncLogGroup:
         Type: "AWS::Logs::LogGroup"
@@ -184,7 +198,7 @@ Resources:
                     }
                   }
                 }
-            RoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/service-role/sg-analysis-step-function-role-ks"
+            RoleArn: !GetAtt SgaStepFunctionIAMRole.Arn
             StateMachineType: "STANDARD"
             LoggingConfiguration:
                 Destinations: 
@@ -206,12 +220,51 @@ Resources:
                 RoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/service-role/SG_Analysis_Amazon_EventBridge_Invoke_Step_Functions"
             EventBusName: "default"
 
+    SgaStartAthenaQueryGlueJobIAMRole:
+        Type: AWS::IAM::Role
+        Properties:
+          AssumeRolePolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Principal:
+                  Service: glue.amazonaws.com
+                Action: sts:AssumeRole
+          Path: /
+          ManagedPolicyArns:
+            - !Ref SgaCloudWatchLogsPolicy
+          Policies:
+            - PolicyName: GlueJobPolicy
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - athena:StartQueryExecution
+                      - athena:GetQueryExecution
+                      - athena:GetQueryResults
+                    Resource: "*"
+            - PolicyName: GlueJobS3Access
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - s3:Get*
+                      - s3:HeadObject
+                      - s3:List*
+                    Resource:
+                      - arn:aws:s3:::security-group-monitoring-test-res-bucket
+                      - arn:aws:s3:::security-group-monitoring-test-res-bucket/*
+                      - arn:aws:s3:::security-group-monitoring-test-bucket-athena
+                      - arn:aws:s3:::security-group-monitoring-test-bucket-athena/*
+
     GlueJob1:
         Type: "AWS::Glue::Job"
         Properties:
             Name: "sg-analysis-run-athena-query-ks"
             Description: "Job to run Athena query on VPC Flow logs and save to S3"
-            Role: !GetAtt IAMRole2.Arn
+            Role: !GetAtt SgaStartAthenaQueryGlueJobIAMRole.Arn
             ExecutionProperty: 
                 MaxConcurrentRuns: 1
             Command: 
@@ -239,44 +292,62 @@ Resources:
             GlueVersion: "1.0"
             MaxCapacity: 0.0625
 
-    GlueJob2:
-        Type: "AWS::Glue::Job"
+    SgaParseFlowLogsGlueJobIAMRole:
+        Type: AWS::IAM::Role
         Properties:
-            Name: "sg-analysis-get-rules-data-ks"
-            Description: "Job to get Security Group rules information"
-            Role: !GetAtt IAMRole2.Arn
-            ExecutionProperty: 
-                MaxConcurrentRuns: 1
-            Command: 
-                Name: "pythonshell"
-                ScriptLocation: !Join
-                                    - ''
-                                    - - 's3://'
-                                      - !Ref S3BucketResources
-                                      - '/scripts/'
-                                      - 'get_security_groups_data.py'
-                PythonVersion: "3.9"
-            DefaultArguments: 
-                --class: "GlueApp"
-                --enable-job-insights: "false"
-                --extra-py-files: !Join
-                                    - ''
-                                    - - 's3://'
-                                      - !Ref S3BucketResources
-                                      - '/libraries/'
-                                      - 'boto3-1.27.1-py3-none-any.whl'
-                --job-language: "python"
-            MaxRetries: 1
-            Timeout: 2880
-            GlueVersion: "1.0"
-            MaxCapacity: 0.0625
-
+          AssumeRolePolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Principal:
+                  Service: glue.amazonaws.com
+                Action: sts:AssumeRole
+          Path: /
+          ManagedPolicyArns:
+            - !Ref SgaCloudWatchLogsPolicy
+          Policies:
+              - PolicyName: GlueJobS3Access
+                PolicyDocument:
+                    Version: '2012-10-17'
+                    Statement:
+                      - Effect: Allow
+                        Action:
+                          - s3:Get*
+                          - s3:HeadObject
+                          - s3:List*
+                        Resource:
+                          - arn:aws:s3:::security-group-monitoring-test-res-bucket
+                          - arn:aws:s3:::security-group-monitoring-test-res-bucket/*
+                          - arn:aws:s3:::security-group-monitoring-test-bucket-athena
+                          - arn:aws:s3:::security-group-monitoring-test-bucket-athena/*
+              - PolicyName: GlueJobDynamoDBPolicy
+                PolicyDocument:
+                  Version: '2012-10-17'
+                  Statement:
+                    - Effect: Allow
+                      Action:
+                        - dynamodb:Query
+                        - dynamodb:GetItem
+                      Resource:
+                        - !GetAtt DynamoTableSGRules.Arn
+                        - !GetAtt DynamoTablENIAnalysis.Arn
+              - PolicyName: GlueJobDynamoDBReadWritePolicy
+                PolicyDocument:
+                  Version: '2012-10-17'
+                  Statement:
+                    - Effect: Allow
+                      Action:
+                        - dynamodb:PutItem
+                        - dynamodb:GetItem
+                        - dynamodb:UpdateItem
+                      Resource: !GetAtt DynamoTableSGAnalysis.Arn
+    
     GlueJob3:
         Type: "AWS::Glue::Job"
         Properties:
             Name: "sg-analysis-flow-logs-parser-ks"
             Description: "Job to parse flow logs and calculate usage"
-            Role: !GetAtt IAMRole2.Arn
+            Role: !GetAtt SgaParseFlowLogsGlueJobIAMRole.Arn
             ExecutionProperty: 
                 MaxConcurrentRuns: 1
             Command: 
@@ -303,29 +374,96 @@ Resources:
             GlueVersion: "1.0"
             MaxCapacity: 1
 
+    SgaGetSgLambdaIAMRole:
+        Type: AWS::IAM::Role
+        Properties:
+          AssumeRolePolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Principal:
+                  Service: lambda.amazonaws.com
+                Action: sts:AssumeRole
+          Path: /
+          ManagedPolicyArns:
+            - !Ref SgaCloudWatchLogsPolicy
+          Policies:
+            - PolicyName: DescribeSecurityGroupsPolicy
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - ec2:DescribeSecurityGroups
+                      - ec2:DescribeSecurityGroupReferences
+                      - ec2:DescribeSecurityGroupRules
+                    Resource: "*"
+            - PolicyName: DynamoDBPermissions
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - dynamodb:PutItem
+                      - dynamodb:Query
+                    Resource: !GetAtt DynamoTableSGRules.Arn
+
     LambdaGetSG:
       Type: "AWS::Lambda::Function"
-      DependsOn: IAMRole2
       Properties:
-        Role: arn:aws:iam::019050653029:role/service-role/SG_Analysis_Glue_Access_Role_KS
+        Role: !GetAtt SgaGetSgLambdaIAMRole.Arn
         Handler: lambda_function.lambda_handler
         Environment:
           Variables:
-            DB_TABLE: sg-analysis-rules-data-ks
+            DB_TABLE: !Ref DynamoTableSGRules
         Runtime: python3.10
         Code:
           S3Bucket: security-group-monitoring-test-bucket-resources
           S3Key: GetSGTest-5635c8ba-9036-4b27-a232-ffb9f8874040.zip
-      
+
+    SgaGetEniLambdaIAMRole:
+        Type: AWS::IAM::Role
+        Properties:
+          AssumeRolePolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Principal:
+                  Service: lambda.amazonaws.com
+                Action: sts:AssumeRole
+          Path: /
+          ManagedPolicyArns:
+            - !Ref SgaCloudWatchLogsPolicy
+          Policies:
+            - PolicyName: DescribeSecurityGroupsPolicy
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - ec2:DescribeNetworkInterfaces
+                      - ec2:DescribeTags
+                      - ec2:DescribeNetworkAcls
+                      - ec2:DescribeRouteTables
+                    Resource: "*"
+            - PolicyName: DynamoDBPermissions
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - dynamodb:PutItem
+                      - dynamodb:Query
+                    Resource: !GetAtt DynamoTablENIAnalysis.Arn
+
     LambdaGetENI:
       Type: "AWS::Lambda::Function"
-      DependsOn: IAMRole2
       Properties:
-        Role: arn:aws:iam::019050653029:role/service-role/SG_Analysis_Glue_Access_Role_KS
+        Role: !GetAtt SgaGetEniLambdaIAMRole.Arn
         Handler: lambda_function.lambda_handler
         Environment:
           Variables:
-            DB_TABLE: sg-analysis-interface-details-ks
+            DB_TABLE: !GetAtt DynamoTablENIAnalysis.Arn
         Runtime: python3.10
         Code:
           S3Bucket: security-group-monitoring-test-bucket-resources


### PR DESCRIPTION
Updated the permissions and roles to follow a more restrictive model. Closes #10.

- Creating managed policy SgaCloudWatchLogsPolicy. Lambda, Glue, and Step Functions all need access to CWL so will use this policy
- Replaced IAMRole with SgaStepFunctionIAMRole for use with Step Function
- Replaced IAMRole2 with roles specific to GlueJobs and Lambda Functions
  - SgaStartAthenQueryGlueJobIAMRole
  - SgaParseFlowLogsGlueJobIAMRole
  - SgaGetSgLambdaIAMRole
  - LambdaGetSG
  - SgaGetEniLambdaIAMRole
- Updated references in Glue Jobs, Lambda Functions, and Step Function to use new roles
- Updated references in Lambda Functions to use !Ref with ddb table env var

Also removed ec2 client from the flow_log_parser script as it isn't needed anymore