### PR TITLE
SGA Lambda Functions Assume Cross Account Role

### DIFF
--- a/templates/sg_rule_analysis.yaml
+++ b/templates/sg_rule_analysis.yaml
@@ -447,6 +447,14 @@ Resources:
                       - dynamodb:PutItem
                       - dynamodb:Query
                     Resource: !GetAtt DynamoTableSGRules.Arn
+            - PolicyName: AssumeCrossAccountRole
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - sts:AssumeRole
+                    Resource: arn:aws:iam:::role/SgaCrossAccountSecurityGroupLambda
 
     SgaGetSgLambda:
       Type: "AWS::Lambda::Function"
@@ -498,6 +506,14 @@ Resources:
                       - dynamodb:PutItem
                       - dynamodb:Query
                     Resource: !GetAtt DynamoTableENIAnalysis.Arn
+            - PolicyName: AssumeCrossAccountRole
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - sts:AssumeRole
+                    Resource: arn:aws:iam:::role/SgaCrossAccountEniLambda
 
     SgaGetEniLambda:
       Type: "AWS::Lambda::Function"

--- a/templates/sg_rule_analysis.yaml
+++ b/templates/sg_rule_analysis.yaml
@@ -80,8 +80,6 @@ Resources:
 
     StepFuncLogGroup:
         Type: "AWS::Logs::LogGroup"
-        Properties:
-            LogGroupName: "/aws/vendedlogs/states/sg-analysis-step-function-logs_KS"
 
     DynamoTableSGRules:
         Type: "AWS::DynamoDB::Table"
@@ -235,7 +233,6 @@ Resources:
     EventsRule:
         Type: "AWS::Events::Rule"
         Properties:
-            Name: "sg-analysis-step-function-ks"
             ScheduleExpression: "cron(0 9 * * ? *)"
             State: "DISABLED"
             Targets: 

--- a/templates/sg_rule_analysis.yaml
+++ b/templates/sg_rule_analysis.yaml
@@ -451,7 +451,7 @@ Resources:
                   - Effect: Allow
                     Action:
                       - sts:AssumeRole
-                    Resource: arn:aws:iam:::role/SgaCrossAccountSecurityGroupLambda
+                    Resource: arn:aws:iam::*:role/SgaCrossAccountSecurityGroupLambda
 
     SgaGetSgLambda:
       Type: "AWS::Lambda::Function"
@@ -510,7 +510,7 @@ Resources:
                   - Effect: Allow
                     Action:
                       - sts:AssumeRole
-                    Resource: arn:aws:iam:::role/SgaCrossAccountEniLambda
+                    Resource: arn:aws:iam::*:role/SgaCrossAccountEniLambda
 
     SgaGetEniLambda:
       Type: "AWS::Lambda::Function"


### PR DESCRIPTION
This PR includes a policy change to the SgaGetSgLambdaIAMRole and SgaGetEniLambdaIAMRole roles to allow the Sga Lambda functions to assume cross account roles