### PR TITLE
Update Analysis Script to Compare Rules with References

### DIFF
--- a/scripts/flow_logs_parser.py
+++ b/scripts/flow_logs_parser.py
@@ -98,7 +98,7 @@ def port_test(rule_port_from,rule_port_to,flow_port):
         return False
 
 def rule_matcher(resp_list,flow):
-    [r.setdefault('match_score',1) for r in resp_list]
+    [r.update({'match_score':1}) for r in resp_list]
     if len(resp_list) == 1:
         return resp_list
     else:

--- a/scripts/flow_logs_parser.py
+++ b/scripts/flow_logs_parser.py
@@ -88,6 +88,15 @@ def ref_rule_dict_builder(ref_rule,ip_address):
     rr = deepcopy(ref_rule)
     rr['properties']['CidrIpv4'] = f'{ip_address}/32'
     return rr
+
+def port_test(rule_port_from,rule_port_to,flow_port):
+    if rule_port_from == -1 and rule_port_to == -1:
+        return True
+    elif flow_port in range(rule_port_from,rule_port_to+1):
+        return True
+    else:
+        return False
+
 def rule_matcher(resp_list,flow):
     [r.setdefault('match_score',1) for r in resp_list]
     if len(resp_list) == 1:

--- a/scripts/flow_logs_parser.py
+++ b/scripts/flow_logs_parser.py
@@ -11,6 +11,8 @@ from awsglue.utils import getResolvedOptions
 from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
 from ipaddress import IPv4Address, IPv4Network
 from hashlib import sha1
+from functools import lru_cache
+from copy import deepcopy
 
 args = getResolvedOptions(sys.argv, ['region', 'FlowLogsAthenaResultsBucket', 'SGRulesTable', 'SGRulesGroupIndex', 'NICInterfaceTable', 'DynamoTableName', 'SGARulesUseIndex', 'path'])
 

--- a/scripts/flow_logs_parser.py
+++ b/scripts/flow_logs_parser.py
@@ -66,6 +66,10 @@ def network_scorer(rule_block):
     network_score = IPv4Network(rule_block).prefixlen
     return network_score
 
+def rule_filter(resp_list):
+    ref_rules = [r for r in resp_list if r['properties'].get('ReferencedGroupInfo')]
+    cidr_rules = [r for r in resp_list if r['properties'].get('CidrIpv4')]
+    return (ref_rules,cidr_rules)
 def rule_matcher(resp_list,flow):
     [r.setdefault('match_score',1) for r in resp_list]
     if len(resp_list) == 1:

--- a/scripts/flow_logs_parser.py
+++ b/scripts/flow_logs_parser.py
@@ -92,7 +92,7 @@ def ref_rule_dict_builder(ref_rule,ip_address):
 def port_test(rule_port_from,rule_port_to,flow_port):
     if rule_port_from == -1 and rule_port_to == -1:
         return True
-    elif flow_port in range(rule_port_from,rule_port_to+1):
+    elif flow_port in range(int(rule_port_from),int(rule_port_to)+1):
         return True
     else:
         return False
@@ -144,7 +144,7 @@ def get_sg_rule_id(sg_id, flow_count, protocol, flow_dir, addr, dstport):
             resp_list = [{k: deserializer.deserialize(v) for k, v in r.items()} for r in response['Items'] if r['properties']['M']['IsEgress']['BOOL'] == True]
         else:
             resp_list = [{k: deserializer.deserialize(v) for k, v in r.items()} for r in response['Items'] if r['properties']['M']['IsEgress']['BOOL'] == False]
-
+        
         try:
             result = rule_matcher(resp_list,flow_object)[0]
             print(f"rule found for flow: sg_rule_id={result['id']},sg_id={result['group_id']},flow_dir={flow_dir},protocol={flow_object['protocol']},addr={flow_object['addr']},dstport={flow_object['port']}")

--- a/scripts/flow_logs_parser.py
+++ b/scripts/flow_logs_parser.py
@@ -83,6 +83,11 @@ def get_sg_ref_ips(sg_id):
         return ref_ips
     else:
         print (f'sg id: {sg_id} not found!')
+
+def ref_rule_dict_builder(ref_rule,ip_address):
+    rr = deepcopy(ref_rule)
+    rr['properties']['CidrIpv4'] = f'{ip_address}/32'
+    return rr
 def rule_matcher(resp_list,flow):
     [r.setdefault('match_score',1) for r in resp_list]
     if len(resp_list) == 1:

--- a/scripts/flow_logs_parser.py
+++ b/scripts/flow_logs_parser.py
@@ -14,7 +14,18 @@ from hashlib import sha1
 from functools import lru_cache
 from copy import deepcopy
 
-args = getResolvedOptions(sys.argv, ['region', 'FlowLogsAthenaResultsBucket', 'SGRulesTable', 'SGRulesGroupIndex', 'NICInterfaceTable', 'DynamoTableName', 'SGARulesUseIndex', 'path'])
+args = getResolvedOptions(sys.argv, 
+    [
+        'region', 
+        'FlowLogsAthenaResultsBucket', 
+        'SGRulesTable', 
+        'SGRulesGroupIndex', 
+        'NICInterfaceTable', 
+        'DynamoTableName', 
+        'SGARulesUseIndex', 
+        'SGSortTableName',
+        'path'
+    ])
 
 s3 = boto3.resource('s3', args['region'])
 dynamodb = boto3.client('dynamodb', args['region'])
@@ -25,6 +36,7 @@ sg_rules_group_idx = args["SGRulesGroupIndex"]
 nic_interface_tbl= args["NICInterfaceTable"]
 dynamodb_tbl_name= args["DynamoTableName"]
 sg_analysis_rules_use_idx= args["SGARulesUseIndex"]
+sg_sort_table= args["SGSortTableName"]
 athena_s3_prefix = args['path']
 date_yst = (date.today() - timedelta(1))
 


### PR DESCRIPTION
This PR implements the ability to analyse flows when a security group rule contains a reference to another security group. This is seen in rules with the property `ReferencedGroupInfo`

Also included are some changes to the analysis which should provide more accurate matching of rules with flows.