### PR TITLE
Batch Query Changes to Flow Logs Parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .venv*
 snippits.py
 vpc_samples/
+*pyc

--- a/scripts/flow_logs_parser.py
+++ b/scripts/flow_logs_parser.py
@@ -26,7 +26,8 @@ args = getResolvedOptions(sys.argv,
         'DynamoTableName', 
         'SGARulesUseIndex', 
         'SGSortTableName',
-        'path'
+        'path',
+        'QueryCsv'
     ])
 
 s3 = boto3.resource('s3', args['region'])
@@ -40,6 +41,7 @@ dynamodb_tbl_name= args["DynamoTableName"]
 sg_analysis_rules_use_idx= args["SGARulesUseIndex"]
 sg_sort_table= args["SGSortTableName"]
 athena_s3_prefix = args['path']
+query_csv = args['QueryCsv']
 date_yst = (date.today() - timedelta(1))
 
 my_bucket = s3.Bucket(flow_logs_athena_results_bucket)
@@ -256,10 +258,10 @@ def get_interface_ddb(id:str) -> dict:
 
 
 def main():
-    s3_folder_path = f's3://{flow_logs_athena_results_bucket}/{athena_s3_prefix}/{date_yst.isoformat().replace("-","/")}/'
+    query_csv_path = f's3://{flow_logs_athena_results_bucket}/{athena_s3_prefix}/{date_yst.isoformat().replace("-","/")}/{query_csv}'
     start = time.time()
     print("Writing rules data to DynamoDB table- started at: "+str(datetime.now()))
-    dfs = wr.s3.read_csv(path=s3_folder_path, chunksize=1000, encoding = 'ISO-8859-1')
+    dfs = wr.s3.read_csv(path=query_csv_path, chunksize=1000, encoding = 'ISO-8859-1')
     for df in dfs:
         try:
             df_row_count = len(df) - 1

--- a/scripts/flow_logs_parser.py
+++ b/scripts/flow_logs_parser.py
@@ -27,7 +27,7 @@ args = getResolvedOptions(sys.argv,
         'SGARulesUseIndex', 
         'SGSortTableName',
         'path',
-        'QueryCsv'
+        'queryCsv'
     ])
 
 s3 = boto3.resource('s3', args['region'])
@@ -41,7 +41,7 @@ dynamodb_tbl_name= args["DynamoTableName"]
 sg_analysis_rules_use_idx= args["SGARulesUseIndex"]
 sg_sort_table= args["SGSortTableName"]
 athena_s3_prefix = args['path']
-query_csv = args['QueryCsv']
+query_csv = args['outputCsv']
 date_yst = (date.today() - timedelta(1))
 
 my_bucket = s3.Bucket(flow_logs_athena_results_bucket)


### PR DESCRIPTION
This PR implements the changes required for supporting batch based jobs in the flow_logs_parser script. This is linked to #74.