### PR TITLE
Change to Distributed Map State

### DIFF
--- a/templates/sg_rule_analysis.yaml
+++ b/templates/sg_rule_analysis.yaml
@@ -137,6 +137,14 @@ Resources:
                           - ''
                           - - !Ref SgaVpcFlowLogBucket
                             - "/*"
+            - PolicyName: StepFunctionInvokeStepFunction
+              PolicyDocument: 
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - states:StartExecution
+                    Resource: "*"
 
 
     SgaEventBridgeIAMManagedPolicy:

--- a/templates/sg_rule_analysis.yaml
+++ b/templates/sg_rule_analysis.yaml
@@ -475,12 +475,18 @@ Resources:
                               "outputCsv.$": "$$.Map.Item.Value"
                             }
                           }
+                        },
+                        "ProcessorConfig": {
+                          "Mode": "DISTRIBUTED",
+                          "ExecutionType": "STANDARD"
                         }
                       },
-                      "End": true
+                      "End": true,
+                      "Label": "ProcessItems",
+                      "MaxConcurrency": 10
                     }
                   }
-                }
+                } 
               - AthenaBucket: !ImportValue sga-athena-bucket-ref
             RoleArn: !GetAtt SgaStepFunctionIAMRole.Arn
             StateMachineType: "STANDARD"

--- a/templates/sg_rule_analysis.yaml
+++ b/templates/sg_rule_analysis.yaml
@@ -491,7 +491,8 @@ Resources:
                       },
                       "End": true,
                       "Label": "ProcessItems",
-                      "MaxConcurrency": 10
+                      "MaxConcurrency": 10,
+                      "ToleratedFailureCount": 9
                     }
                   }
                 } 


### PR DESCRIPTION
This PR implements a change to the ProcessItems map state, and switches from inline to distributed. If an inline map state fails in any part of the process, all iterations will be aborted, which is not desired as each analysis triggered is independent of the others. The distributed map state allows for a failure tolerance to be set.